### PR TITLE
Fixed the black bars seen on Mac

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -601,7 +601,7 @@ void main( void ) {
 				cacheUniformLocation( program, 'resolution' );
 				cacheUniformLocation( program, 'texture' );
 
-				screenVertexPosition = gl.getAttribLocation(currentProgram, "position");
+				screenVertexPosition = gl.getAttribLocation(screenProgram, "position");
 				gl.enableVertexAttribArray( screenVertexPosition );
 
 			}


### PR DESCRIPTION
This patch should make shaders full-screen again, horray!  This was a strange issue where the Mac was assigning vertex attribute locations differently from other platforms (Win/Linux/Android).  As a result of the mixup, Mac users saw the top and bottom of the window turn black, or would see the shader in a tiny sub-window of the available area.  Thumbnails were likewise getting black bars.

The vertex attributes are tracked separately now, so the Mac's attribute location assignments are properly handled, and all these issues with black areas should be fixed.  Old existing thumbnails won't get updated automatically, but future ones should come out full-size.
