### PR TITLE
Add 'fork' button to old shaders

### DIFF
--- a/server/assets/js/helpers.js
+++ b/server/assets/js/helpers.js
@@ -30,7 +30,7 @@ function get_user_id() {
 }
 
 function am_i_owner() {
-	return (effect_owner==false || effect_owner==get_user_id());
+	return (effect_owner && effect_owner==get_user_id());
 }
 
 function load_url_code() {


### PR DESCRIPTION
Hi, this is a one-line change that should make old shaders display the 'fork' button instead of save.  Old shaders (in the e#100 and prior range) have 'false' as their owners and can be saved by anyone, this changes it so they should be forked from now on.
